### PR TITLE
fix: wire boundsearch_en option into OPTION::init()

### DIFF
--- a/src/cpu/options.cpp
+++ b/src/cpu/options.cpp
@@ -169,6 +169,7 @@ void OPTION::init()
 {
 	autarky_en			= opt_autarky_en;
 	autarky_sleep_en	= opt_autarky_sleep_en;
+	boundsearch_en		= opt_boundsearch_en;
 	bumpreason_en		= opt_bumpreason_en;
 	chrono_en			= opt_chrono_en;
 	chrono_min			= opt_chrono_min;

--- a/src/gpu/options.cpp
+++ b/src/gpu/options.cpp
@@ -168,6 +168,7 @@ void OPTION::init()
 {
 	autarky_en = opt_autarky_en;
 	autarky_sleep_en = opt_autarky_sleep_en;
+	boundsearch_en = opt_boundsearch_en;
 	bumpreason_en = opt_bumpreason_en;
 	chrono_en = opt_chrono_en;
 	chrono_min = opt_chrono_min;


### PR DESCRIPTION
The global `opt_boundsearch_en` (`-boundsearch` / `-no-boundsearch` CLI flag) is parsed from command-line arguments but never copied into `opts.boundsearch_en` inside `OPTION::init()`. This causes the `runningout()` check in `solver.h` to always see `opts.boundsearch_en` as `false`, making the bound-search feature silently non-functional.

**Fix:** Added the missing `boundsearch_en = opt_boundsearch_en;` assignment in `OPTION::init()` in both:
- `src/cpu/options.cpp`
- `src/gpu/options.cpp`